### PR TITLE
fix to bug in CheckPrime

### DIFF
--- a/Maths/CheckPrime.php
+++ b/Maths/CheckPrime.php
@@ -18,7 +18,7 @@ function isPrime(int $number)
     }
 
     $i = 3;
-    while ($i < sqrt($number)) {
+    while ($i <= sqrt($number)) {
         if ($number % $i === 0) {
             return false;
         }

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,20 @@
 {
-	"name" : "thealgorithms/php",
-	"description": "All Algorithms implemented in PHP",
-	"license": "MIT",
-	"require": {
-		"phan/phan": "^2.7"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "^9"
-	},
-	"scripts": {
-		"test": "vendor/bin/phpunit tests"
-	}
+  "name" : "thealgorithms/php",
+  "description": "All Algorithms implemented in PHP",
+  "config": {
+    "platform": {
+      "php": "7.3.0"
+    }
+  },
+  "license": "MIT",
+  "require": {
+    "php": "7.3.0",
+    "phan/phan": "^2.7"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit tests"
+  }
 }


### PR DESCRIPTION
closes #38 
### Bug
isPrime() returns true to the square of a number, for example.
`isPrime(49) // return true instead of false`

### fix
``` diff
-while ($i < sqrt($number)) {...}
+while ($i <= sqrt($number)) {...}

```