### PR TITLE
Add Mono-Alphabetic Cipher 

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -4,7 +4,7 @@
   * [Caesarcipher](./ciphers/caesarCipher.php)
   * [Morsecode](./ciphers/morseCode.php)
   * [Xorcipher](./ciphers/XORCipher.php)
-  * [Mono-AlphabeticCipher](./ciphers/monoAlphabeticCipher.php)
+  * [MonoAlphabeticCipher](./ciphers/monoAlphabeticCipher.php)
 
 ## Conversions
   * [Binarytodecimal](./Conversions/BinaryToDecimal.php)

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -64,6 +64,7 @@
 ## Tests
   * [Cipherstest](./tests/CiphersTest.php)
   * [Ciphertest](./tests/CipherTest.php)
+  * [MonoAlphabeticCipherTest](./tests/MonoAlphabeticCipherTest.php)
   * [Conversionstest](./tests/ConversionsTest.php)
   * [Decimaltobinarytest](./tests/DecimalToBinaryTest.php)
   * [Fibonaccisearchtest](./tests/fibonacciSearchTest.php)

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -4,6 +4,7 @@
   * [Caesarcipher](./ciphers/caesarCipher.php)
   * [Morsecode](./ciphers/morseCode.php)
   * [Xorcipher](./ciphers/XORCipher.php)
+  * [Mono-AlphabeticCipher](./ciphers/monoAlphabeticCipher.php.php)
 
 ## Conversions
   * [Binarytodecimal](./Conversions/BinaryToDecimal.php)

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -4,7 +4,7 @@
   * [Caesarcipher](./ciphers/caesarCipher.php)
   * [Morsecode](./ciphers/morseCode.php)
   * [Xorcipher](./ciphers/XORCipher.php)
-  * [Mono-AlphabeticCipher](./ciphers/monoAlphabeticCipher.php.php)
+  * [Mono-AlphabeticCipher](./ciphers/monoAlphabeticCipher.php)
 
 ## Conversions
   * [Binarytodecimal](./Conversions/BinaryToDecimal.php)

--- a/ciphers/monoAlphabeticCipher.php
+++ b/ciphers/monoAlphabeticCipher.php
@@ -22,7 +22,8 @@ function maEncrypt($key, $alphabet, $text){
     return cipher($key, $alphabet, $text);
 }
 
-function decrypt($key, $alphabet, $text){
+function maDecrypt($key, $alphabet, $text){
+
     return cipher($alphabet, $key, $text);
 }
 

--- a/ciphers/monoAlphabeticCipher.php
+++ b/ciphers/monoAlphabeticCipher.php
@@ -24,7 +24,8 @@ function maEncrypt($key, $alphabet, $text){
 
 function maDecrypt($key, $alphabet, $text){
 
-    return cipher($alphabet, $key, $text);
+    return monoAlphabeticCipher($alphabet, $key, $text);
+
 }
 
 ?> 

--- a/ciphers/monoAlphabeticCipher.php
+++ b/ciphers/monoAlphabeticCipher.php
@@ -17,7 +17,8 @@ function monoAlphabeticCipher($key, $alphabet, $text){
     return $cipherText;
 }
 
-function encrypt($key, $alphabet, $text){
+function maEncrypt($key, $alphabet, $text){
+
     return cipher($key, $alphabet, $text);
 }
 

--- a/ciphers/monoAlphabeticCipher.php
+++ b/ciphers/monoAlphabeticCipher.php
@@ -1,0 +1,27 @@
+<?php
+// A mono-alphabetic cipher is a simple substitution cipher
+// https://www.101computing.net/mono-alphabetic-substitution-cipher/
+
+function cipher($key, $alphabet, $text){
+    $cipherText = ''; // the cipher text (can be decrypted and encrypted)
+
+    if ( strlen($key) != strlen($alphabet) ) { return false; } // check if the text length matches
+    $text = preg_replace('/[0-9]+/', '', $text); // remove all the numbers
+    
+    for( $i = 0; $i < strlen($text); $i++ ){
+        $index = strripos( $alphabet, $text[$i] );
+        if( $text[$i] == " " ){ $cipherText .= " "; }
+        else{ $cipherText .= ( ctype_upper($text[$i]) ? strtoupper($key[$index]) : $key[$index] ); }
+    }
+    return $cipherText;
+}
+
+function encrypt($key, $alphabet, $text){
+    return cipher($key, $alphabet, $text);
+}
+
+function decrypt($key, $alphabet, $text){
+    return cipher($alphabet, $key, $text);
+}
+
+?> 

--- a/ciphers/monoAlphabeticCipher.php
+++ b/ciphers/monoAlphabeticCipher.php
@@ -19,7 +19,8 @@ function monoAlphabeticCipher($key, $alphabet, $text){
 
 function maEncrypt($key, $alphabet, $text){
 
-    return cipher($key, $alphabet, $text);
+    return monoAlphabeticCipher($key, $alphabet, $text);
+
 }
 
 function maDecrypt($key, $alphabet, $text){

--- a/ciphers/monoAlphabeticCipher.php
+++ b/ciphers/monoAlphabeticCipher.php
@@ -2,7 +2,8 @@
 // A mono-alphabetic cipher is a simple substitution cipher
 // https://www.101computing.net/mono-alphabetic-substitution-cipher/
 
-function cipher($key, $alphabet, $text){
+function monoAlphabeticCipher($key, $alphabet, $text){
+
     $cipherText = ''; // the cipher text (can be decrypted and encrypted)
 
     if ( strlen($key) != strlen($alphabet) ) { return false; } // check if the text length matches

--- a/tests/MonoAlphabeticCipherTest.php
+++ b/tests/MonoAlphabeticCipherTest.php
@@ -12,7 +12,8 @@ class MonoAlphabeticCipherTest extends TestCase
         $text = "I love1234 GitHub";
         $encryptedText = "O ambg XojFdh";
 
-        assertEquals(encrypt($key, $alphabet, $text), $encryptedText);
+        assertEquals(maEncrypt($key, $alphabet, $text), $encryptedText);
+
         assertEquals(decrypt($key, $alphabet, $encryptedText), "I love GitHub");
     }
 }

--- a/tests/MonoAlphabeticCipherTest.php
+++ b/tests/MonoAlphabeticCipherTest.php
@@ -1,0 +1,20 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertEquals;
+
+require_once __DIR__ . '/../app/monoAlphabeticCipher.php';
+
+class MonoAlphabeticCipherTest extends TestCase
+{
+    public function testLala(){
+        $alphabet = "abcdefghijklmnopqrstuvwxyz";
+        $key = "yhkqgvxfoluapwmtzecjdbsnri";
+        $text = "I love1234 GitHub";
+        $encryptedText = "O ambg XojFdh";
+
+        assertEquals(encrypt($key, $alphabet, $text), $encryptedText);
+        assertEquals(decrypt($key, $alphabet, $encryptedText), "I love GitHub");
+    }
+}
+
+?>

--- a/tests/MonoAlphabeticCipherTest.php
+++ b/tests/MonoAlphabeticCipherTest.php
@@ -14,7 +14,8 @@ class MonoAlphabeticCipherTest extends TestCase
 
         assertEquals(maEncrypt($key, $alphabet, $text), $encryptedText);
 
-        assertEquals(decrypt($key, $alphabet, $encryptedText), "I love GitHub");
+        assertEquals(maDecrypt($key, $alphabet, $encryptedText), "I love GitHub");
+
     }
 }
 

--- a/tests/MonoAlphabeticCipherTest.php
+++ b/tests/MonoAlphabeticCipherTest.php
@@ -2,11 +2,11 @@
 use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertEquals;
 
-require_once __DIR__ . '/../app/monoAlphabeticCipher.php';
+require_once __DIR__ . '/../ciphers/monoAlphabeticCipher.php';
 
 class MonoAlphabeticCipherTest extends TestCase
 {
-    public function testLala(){
+    public function testMonoAlphabeticCipher(){
         $alphabet = "abcdefghijklmnopqrstuvwxyz";
         $key = "yhkqgvxfoluapwmtzecjdbsnri";
         $text = "I love1234 GitHub";


### PR DESCRIPTION
A mono-alphabetic cipher is a simple substitution cipher where each letter of the sentence is replaced with another letter of the alphabet. It uses a fixed key which consists of the 26 letters of a shuffled alphabet.