### PR TITLE
chore: update `actions/setup-python` to `v5`

### DIFF
--- a/.github/workflows/directory_workflow.yml
+++ b/.github/workflows/directory_workflow.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
       - name: Setup Git Specs
         run: |
           git config --global user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
This PR updates `actions/setup-python` to `v5`. Please note that the updated workflow _works on [my end](https://github.com/vil02/PHP/actions/runs/7532940311)_.